### PR TITLE
Another way for gpu polymorphism via the new VariantClass 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        cuda: ["11.4.0", "12.1.0"]
+        cuda: ["12.5.0"]
         cuda_arch: ["75"]
         os: ["windows-2019"]
         spectral: ["ON", "OFF"]

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@
 #### Requirements
 
 - Nvidia RTX GPU (Turing or higher).
-- [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) **7.3+** and [CUDA](https://developer.nvidia.com/cuda-toolkit) **11.4+** (current develop environment: OptiX 8 and CUDA 12).
+- [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) **7.5+** and [CUDA](https://developer.nvidia.com/cuda-toolkit) **12.5+**.
 - [Vulkan SDK](https://vulkan.lunarg.com/) **1.3+**.
 
 This project is developed with on Windows (MSVC). It cannot compile on Linux. 
 
-> *KiRaRay* now uses Vulkan for better interoperability with CUDA, and extensibility to rasterization-based render passes. If Vulkan is not desired, check the [legacy-GL](https://github.com/cuteday/KiRaRay/tree/legacy-GL) branch that instead depends on OpenGL.
+> *KiRaRay* has bumped the required CUDA version to 12.5 for newer libcu++ features. The most recent legacy version on CUDA 11.4 is at the [cu114](https://github.com/cuteday/KiRaRay/tree/cu114) branch.
+
+> *KiRaRay* now uses Vulkan for interoperability with CUDA. If Vulkan is not desired, check the [legacy-GL](https://github.com/cuteday/KiRaRay/tree/legacy-GL) branch that instead depends on OpenGL.
 
 #### Cloning the repository
 

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -16,8 +16,11 @@
 
 #include "config.h"	
 
-#ifdef __INTELLISENSE__
-#pragma diag_suppress 40		// suppress lambda error for visual studio
+#ifdef  __INTELLISENSE__
+#pragma diag_suppress   40		// suppress lambda error for visual studio
+#ifndef _HAS_CXX17
+#define _HAS_CXX17      1
+#endif
 #endif
 
 using std::string;

--- a/src/core/device/taggedptr.h
+++ b/src/core/device/taggedptr.h
@@ -9,7 +9,7 @@ NAMESPACE_BEGIN(krr)
 // TaggedPointer Definition
 template <typename... Ts>
 class TaggedPointer {
-  public:
+public:
 	// TaggedPointer Public Types
 	using Types = TypePack<Ts...>;
 
@@ -123,7 +123,7 @@ class TaggedPointer {
 		return Dispatch<F, R, Ts...>(func, (const void*)nullptr, index);
 	}
 
-  private:
+private:
 	static_assert(sizeof(uintptr_t) == 8, "Expected uintptr_t to be 64 bits");
 	static constexpr int tagShift = 57;
 	static constexpr int tagBits = 64 - tagShift;

--- a/src/core/device/taggedptr.h
+++ b/src/core/device/taggedptr.h
@@ -1,14 +1,16 @@
-// Code taken and modified from pbrt-v4,  
+// Code taken and modified from pbrt-v4,
 // Originally licensed under the Apache License, Version 2.0.
 #pragma once
 
 #include "types.h"
 
+#include <variant>
+#include <cuda/std/variant>
+
 NAMESPACE_BEGIN(krr)
 
 // TaggedPointer Definition
-template <typename... Ts>
-class TaggedPointer {
+template <typename... Ts> class TaggedPointer {
 public:
 	// TaggedPointer Public Types
 	using Types = TypePack<Ts...>;
@@ -16,74 +18,64 @@ public:
 	// TaggedPointer Public Methods
 	TaggedPointer() = default;
 
-	template <typename T>
-	KRR_CALLABLE TaggedPointer(T *ptr) {
+	template <typename T> KRR_CALLABLE TaggedPointer(T *ptr) {
 		uintptr_t iptr = reinterpret_cast<uintptr_t>(ptr);
 		DCHECK_EQ(iptr & ptrMask, iptr);
 		constexpr unsigned int type = typeIndex<T>();
-		bits = iptr | ((uintptr_t)type << tagShift);
+		bits						= iptr | ((uintptr_t) type << tagShift);
 	}
 
-	KRR_CALLABLE TaggedPointer(void* ptr, unsigned int type) {
+	KRR_CALLABLE TaggedPointer(void *ptr, unsigned int type) {
 		uintptr_t iptr = reinterpret_cast<uintptr_t>(ptr);
 		DCHECK_EQ(iptr & ptrMask, iptr);
 		DCHECK_LE(type, maxTag());
-		bits = iptr | ((uintptr_t)type << tagShift);
+		bits = iptr | ((uintptr_t) type << tagShift);
 	}
 
 	KRR_CALLABLE TaggedPointer(std::nullptr_t np) {}
 
 	KRR_CALLABLE TaggedPointer(const TaggedPointer &t) { bits = t.bits; }
-	
+
 	KRR_CALLABLE TaggedPointer &operator=(const TaggedPointer &t) {
 		bits = t.bits;
 		return *this;
 	}
 
-	template <typename T>
-	KRR_CALLABLE static constexpr unsigned int typeIndex() {
+	template <typename T> KRR_CALLABLE static constexpr unsigned int typeIndex() {
 		using Tp = typename std::remove_cv_t<T>;
-		if constexpr (std::is_same_v<Tp, std::nullptr_t>)
-			return 0;
+		if constexpr (std::is_same_v<Tp, std::nullptr_t>) return 0;
 		return 1 + IndexOf<Tp, Types>::count;
 	}
 
 	// the index of the type pack plus one. tag=0 means nullptr.
 	KRR_CALLABLE unsigned int tag() const { return ((bits & tagMask) >> tagShift); }
-	template <typename T>
-	KRR_CALLABLE bool is() const {
-		return tag() == typeIndex<T>();
-	}
+	template <typename T> KRR_CALLABLE bool is() const { return tag() == typeIndex<T>(); }
 
 	KRR_CALLABLE static constexpr unsigned int maxTag() { return sizeof...(Ts); }
 	KRR_CALLABLE static constexpr unsigned int numTags() { return maxTag() + 1; }
 
 	KRR_CALLABLE explicit operator bool() const { return (bits & ptrMask) != 0; }
 
-	KRR_CALLABLE bool operator < (const TaggedPointer &tp) const { return bits < tp.bits; }
+	KRR_CALLABLE bool operator<(const TaggedPointer &tp) const { return bits < tp.bits; }
 
-	template <typename T>
-	KRR_CALLABLE T *cast() {
+	template <typename T> KRR_CALLABLE T *cast() {
 		DCHECK(is<T>());
 		return reinterpret_cast<T *>(ptr());
 	}
 
-	template <typename T>
-	KRR_CALLABLE const T * cast() const {
+	template <typename T> KRR_CALLABLE const T *cast() const {
 		DCHECK(is<T>());
 		return reinterpret_cast<const T *>(ptr());
 	}
 
-	template <typename T>
-	KRR_CALLABLE T *castOrNullptr() {
+	template <typename T> KRR_CALLABLE T *castOrNullptr() {
 		if (is<T>())
 			return reinterpret_cast<T *>(ptr());
 		else
 			return nullptr;
 	}
 
-	template <typename T>
-	KRR_CALLABLE const T *castOrNullptr() const {
+	template <typename T> KRR_CALLABLE const T *castOrNullptr() const {
 		if (is<T>())
 			return reinterpret_cast<const T *>(ptr());
 		else
@@ -91,45 +83,131 @@ public:
 	}
 
 	KRR_CALLABLE bool operator==(const TaggedPointer &tp) const { return bits == tp.bits; }
-	
+
 	KRR_CALLABLE bool operator!=(const TaggedPointer &tp) const { return bits != tp.bits; }
 
 	KRR_CALLABLE void *ptr() { return reinterpret_cast<void *>(bits & ptrMask); }
 
 	KRR_CALLABLE const void *ptr() const { return reinterpret_cast<const void *>(bits & ptrMask); }
 
-	template <typename F>
-	KRR_CALLABLE decltype(auto) dispatch(F &&func) {
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) {
 		DCHECK(ptr());
 		using R = typename ReturnType<F, Ts...>::type;
 		return Dispatch<F, R, Ts...>(func, ptr(), tag() - 1);
 	}
 
 	KRR_CALLABLE size_t realSize() const {
-		auto f = [&](auto* ptr)-> size_t {return sizeof * ptr; };
+		auto f = [&](auto *ptr) -> size_t {  return sizeof *ptr; };
 		return dispatch(f);
 	}
 
-	template <typename F>
-	KRR_CALLABLE decltype(auto) dispatch(F &&func) const {
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) const {
 		DCHECK(ptr());
 		using R = typename ReturnType<F, Ts...>::type;
 		return Dispatch<F, R, Ts...>(func, ptr(), tag() - 1);
 	}
 
-	template <typename F>
-	KRR_CALLABLE static decltype(auto) dispatch(F&& func, int index) {
+	template <typename F> KRR_CALLABLE static decltype(auto) dispatch(F &&func, int index) {
 		using R = typename ReturnType<F, Ts...>::type;
-		return Dispatch<F, R, Ts...>(func, (const void*)nullptr, index);
+		return Dispatch<F, R, Ts...>(func, (const void *) nullptr, index);
 	}
 
 private:
 	static_assert(sizeof(uintptr_t) == 8, "Expected uintptr_t to be 64 bits");
-	static constexpr int tagShift = 57;
-	static constexpr int tagBits = 64 - tagShift;
+	static constexpr int tagShift	  = 57;
+	static constexpr int tagBits	  = 64 - tagShift;
 	static constexpr uint64_t tagMask = ((1ull << tagBits) - 1) << tagShift;
 	static constexpr uint64_t ptrMask = ~tagMask;
-	uintptr_t bits = 0;
+	uintptr_t bits					  = 0;
+};
+
+template <typename... Ts> class VariantClass {
+public:
+	// TaggedPointer Public Types
+	using Types = TypePack<Ts...>;
+
+	// TaggedPointer Public Methods
+	VariantClass() = default;
+
+	template <typename T> KRR_CALLABLE VariantClass(T value) {
+		static_assert(HasType<T, Types>::value, "Type not present in the type pack!");
+		data = value;
+	}
+
+	template <typename T> VariantClass &operator=(T value) {
+		static_assert(HasType<T, Types>::value, "Type not present in the type pack!");
+		data = value;
+		return *this;
+	}
+
+	template <typename T> KRR_CALLABLE static constexpr unsigned int typeIndex() {
+		using Tp = typename std::remove_cv_t<T>;
+		if constexpr (std::is_same_v<Tp, std::nullptr_t>) return 0;
+		return 1 + IndexOf<Tp, Types>::count;
+	}
+
+	// the index of the type pack plus one. tag=0 means nullptr.
+	KRR_CALLABLE int index() const { return static_cast<int>(data.index()); }
+	template <typename T> KRR_CALLABLE bool is() const { return index() == typeIndex<T>(); }
+
+	KRR_CALLABLE static constexpr unsigned int maxIndex() { return sizeof...(Ts); }
+	KRR_CALLABLE static constexpr unsigned int numIndices() { return maxIndex() + 1; }
+
+	KRR_CALLABLE explicit operator bool() const { return data.index() != 0; }
+
+	template <typename T> KRR_CALLABLE T *cast() {
+		DCHECK(is<T>());
+		return reinterpret_cast<T *>(ptr());
+	}
+
+	template <typename T> KRR_CALLABLE const T *cast() const {
+		DCHECK(is<T>());
+		return reinterpret_cast<const T *>(ptr());
+	}
+
+	template <typename T> KRR_CALLABLE T *castOrNullptr() {
+		if (is<T>())
+			return reinterpret_cast<T *>(ptr());
+		else
+			return nullptr;
+	}
+
+	template <typename T> KRR_CALLABLE const T *castOrNullptr() const {
+		if (is<T>())
+			return reinterpret_cast<const T *>(ptr());
+		else
+			return nullptr;
+	}
+
+	KRR_CALLABLE void *ptr() { return reinterpret_cast<void *>(std::get_if<data.index()>(data)); }
+
+	KRR_CALLABLE const void *ptr() const {
+		return reinterpret_cast<const void *>(std::get_if<data.index()>(data));
+	}
+
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) {
+		DCHECK(ptr());
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, ptr(), index() - 1);
+	}
+
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) const {
+		DCHECK(ptr());
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, ptr(), index() - 1);
+	}
+
+	template <typename F> KRR_CALLABLE static decltype(auto) dispatch(F &&func, int index) {
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, (const void *) nullptr, index);
+	}
+
+protected:
+#ifdef KRR_DEVICE_CODE
+	cuda::std::variant<cuda::std::monostate, Ts...> data;
+#else
+	std::variant<std::monostate, Ts...> data;
+#endif
 };
 
 NAMESPACE_END(krr)

--- a/src/core/device/types.h
+++ b/src/core/device/types.h
@@ -1,6 +1,7 @@
 // Code taken and modified from pbrt-v4,
 // Originally licensed under the Apache License, Version 2.0.
 #pragma once
+#include "common.h"
 
 #include <algorithm>
 #include <string>
@@ -10,9 +11,7 @@
 #include <shared_mutex>
 #include <tuple>
 
-#include "common.h"
 #include "util/check.h"
-
 NAMESPACE_BEGIN(krr)
 
 template <typename... Ts>

--- a/src/core/device/types.h
+++ b/src/core/device/types.h
@@ -108,6 +108,25 @@ struct MapType<M, TypePack<T, Ts...>> {
 	using type = typename Prepend<M<T>, typename MapType<M, TypePack<Ts...>>::type>::type;
 };
 
+template <typename T, typename... Ts> 
+struct MaximumSizeOfTypePack {
+	static constexpr size_t value = sizeof(T);
+};
+template <typename T, typename... Ts> 
+struct MaximumSizeOfTypePack<TypePack<T, Ts...>> {
+	static constexpr size_t value = std::max(sizeof(T), MaximumSizeOfTypePack<TypePack<Ts...>>::value);
+};
+
+template <typename T>
+constexpr size_t MaximumSizeOfTypes() {
+	return sizeof(T);
+}
+
+template <typename T, typename... Ts>
+constexpr size_t MaximumSizeOfTypes() {
+	return std::max(sizeof(T), MaximumSizeOfTypes<Ts...>());
+}
+
 // TaggedPointer Helper Templates
 template <typename F, typename R, typename T>
 KRR_CALLABLE R Dispatch(F &&func, const void *ptr, int index) {

--- a/src/core/device/variant.h
+++ b/src/core/device/variant.h
@@ -1,0 +1,124 @@
+#pragma once
+/* An utility that is based on std::variant and inspired by TaggedPointer.
+* It wraps a variant and implements member function dispatching at runtime,
+* which is similar to the virtual function mechanism but purposed for device polymorphism.
+*/
+#include "types.h"
+
+#include <variant>
+#include <cuda/std/variant>
+
+NAMESPACE_BEGIN(krr)
+
+template <class Variant, size_t I = 0>
+KRR_HOST Variant VariantFromIndex(size_t index) {
+	/* Constructing a variant with std::in_place_index is cxx17 which cudac currently does not support */
+	if constexpr (I >= std::variant_size_v<Variant>) 
+		return Variant{std::in_place_index<0>};
+    return index == 0 ?
+		Variant{std::in_place_index<I>} : VariantFromIndex<Variant, I + 1>(index - 1);
+}
+
+template <typename V, typename T>
+KRR_CALLABLE void DefaultConstruct(V& var, size_t index) {
+	DCHECK_EQ(index, 0);
+	if (index == 0) var = T();
+}
+
+template <typename V, typename T, typename... Ts,
+		  typename = typename std::enable_if_t<(sizeof...(Ts) > 0)>>
+KRR_CALLABLE void DefaultConstruct(V& var, size_t index) {
+	if (index == 0) var = T();
+	else DefaultConstruct<V, Ts...>(var, index - 1);
+}
+
+template <typename... Ts> class VariantClass {
+public:
+	using Types = TypePack<Ts...>;
+
+	VariantClass() = default;
+
+	template <typename T> KRR_CALLABLE VariantClass(T value) {
+		static_assert(HasType<T, Types>::value, "Type not present in the type pack!");
+		data = value;
+	}
+
+	template <typename T> KRR_CALLABLE VariantClass &operator=(T value) {
+		static_assert(HasType<T, Types>::value, "Type not present in the type pack!");
+		data = value;
+		return *this;
+	}
+
+	template <typename T> KRR_CALLABLE static constexpr unsigned int typeIndex() {
+		using Tp = typename std::remove_cv_t<T>;
+		if constexpr (std::is_same_v<Tp, std::nullptr_t>) return 0;
+		return 1 + IndexOf<Tp, Types>::count;
+	}
+
+	// the index of the type pack plus one. tag=0 means nullptr.
+	KRR_CALLABLE int index() const { return static_cast<int>(data.index()); }
+	template <typename T> KRR_CALLABLE bool is() const { return index() == typeIndex<T>(); }
+
+	KRR_CALLABLE static constexpr unsigned int maxIndex() { return sizeof...(Ts); }
+	KRR_CALLABLE static constexpr unsigned int numIndices() { return maxIndex() + 1; }
+
+	KRR_CALLABLE explicit operator bool() const { return data.index() != 0; }
+
+	template <typename T> KRR_CALLABLE T *cast() {
+		DCHECK(is<T>());
+		return reinterpret_cast<T *>(ptr());
+	}
+
+	template <typename T> KRR_CALLABLE const T *cast() const {
+		DCHECK(is<T>());
+		return reinterpret_cast<const T *>(ptr());
+	}
+
+	template <typename T> KRR_CALLABLE T *castOrNullptr() {
+		if (is<T>())
+			return reinterpret_cast<T *>(ptr());
+		else
+			return nullptr;
+	}
+
+	template <typename T> KRR_CALLABLE const T *castOrNullptr() const {
+		if (is<T>())
+			return reinterpret_cast<const T *>(ptr());
+		else
+			return nullptr;
+	}
+
+	KRR_CALLABLE void *ptr() { return reinterpret_cast<void *>(&data); }
+	KRR_CALLABLE const void *ptr() const { return reinterpret_cast<const void *>(&data); }
+
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) {
+		DCHECK(ptr());
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, ptr(), index() - 1);
+	}
+
+	template <typename F> KRR_CALLABLE decltype(auto) dispatch(F &&func) const {
+		DCHECK(ptr());
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, ptr(), index() - 1);
+	}
+
+	template <typename F> KRR_CALLABLE static decltype(auto) dispatch(F &&func, int index) {
+		using R = typename ReturnType<F, Ts...>::type;
+		return Dispatch<F, R, Ts...>(func, (const void *) nullptr, index);
+	}
+
+protected:
+	KRR_CALLABLE void defaultConstruct(size_t index) {
+		DefaultConstruct<decltype(data), Ts...>(data, index);
+	}
+
+#ifdef KRR_DEVICE_CODE
+	/* note that cudac supports variant features only until cxx14. */
+	cuda::std::variant<cuda::std::monostate, Ts...> data;
+#else
+	std::variant<std::monostate, Ts...> data;
+#endif
+};
+
+NAMESPACE_END(krr)

--- a/src/misc/render/ppg/integrator.cpp
+++ b/src/misc/render/ppg/integrator.cpp
@@ -162,8 +162,8 @@ void PPGPathTracer::handleIntersections() {
 			Vector3f wiLocal		  = intr.toLocal(wiWorld);
 
 			float lightPdf	= sampledLight.pdf * ls.pdf;
-			Spectrum bsdfVal	= BxDF::f(intr, woLocal, wiLocal, (int) intr.sd.bsdfType);
-			float bsdfPdf	= light.isDeltaLight() ? 0 : BxDF::pdf(intr, woLocal, wiLocal, (int) intr.sd.bsdfType);
+			Spectrum bsdfVal	= BxDF::f(intr, woLocal, wiLocal);
+			float bsdfPdf	= light.isDeltaLight() ? 0 : BxDF::pdf(intr, woLocal, wiLocal);
 			if (lightPdf > 0 && bsdfVal.any()) {
 				ShadowRayWorkItem sw = {};
 				sw.ray				 = shadowRay;
@@ -429,14 +429,14 @@ KRR_CALLABLE BSDFSample PPGPathTracer::sample(Sampler& sampler,
 
 	if (!m_isBuilt || !dTree || !enableGuiding || (bsdfType & BSDF_SPECULAR)
 		|| bsdfSamplingFraction == 1 || depth >= MAX_GUIDED_DEPTH) {
-		sample = BxDF::sample(intr, woLocal, sampler, (int)intr.sd.bsdfType);
+		sample = BxDF::sample(intr, woLocal, sampler);
 		bsdfPdf = sample.pdf;
 		dTreePdf = 0;
 		return sample;
 	}
 
 	if (bsdfSamplingFraction > 0 && sampler.get1D() < bsdfSamplingFraction) {
-		sample = BxDF::sample(intr, woLocal, sampler, (int)intr.sd.bsdfType);
+		sample = BxDF::sample(intr, woLocal, sampler);
 		bsdfPdf = sample.pdf;
 		dTreePdf = dTree->pdf(intr.toWorld(sample.wi));
 		sample.pdf = bsdfSamplingFraction * bsdfPdf + (1 - bsdfSamplingFraction) * dTreePdf;
@@ -444,7 +444,7 @@ KRR_CALLABLE BSDFSample PPGPathTracer::sample(Sampler& sampler,
 	}
 	else {
 		sample.wi = intr.toLocal(dTree->sample(sampler));
-		sample.f = BxDF::f(intr, woLocal, sample.wi, (int)intr.sd.bsdfType);
+		sample.f = BxDF::f(intr, woLocal, sample.wi);
 		sample.flags = BSDF_GLOSSY | (SameHemisphere(sample.wi, woLocal) ?
 			BSDF_REFLECTION : BSDF_TRANSMISSION);
 		sample.pdf = evalPdf(bsdfPdf, dTreePdf, depth, intr, sample.wi,
@@ -460,10 +460,10 @@ KRR_CALLABLE float PPGPathTracer::evalPdf(float& bsdfPdf, float& dTreePdf, int d
 	bsdfPdf = dTreePdf = 0;
 	if (!m_isBuilt || !dTree || !enableGuiding || (bsdfType & BSDF_SPECULAR)
 		|| alpha == 1 || depth >= MAX_GUIDED_DEPTH) {
-		return bsdfPdf = BxDF::pdf(intr, woLocal, wiLocal, (int)intr.sd.bsdfType);
+		return bsdfPdf = BxDF::pdf(intr, woLocal, wiLocal);
 	}
 	if (alpha > 0) {
-		bsdfPdf = BxDF::pdf(intr, woLocal, wiLocal, (int)intr.sd.bsdfType);
+		bsdfPdf = BxDF::pdf(intr, woLocal, wiLocal);
 		if (isinf(bsdfPdf) || isnan(bsdfPdf)) {
 			return bsdfPdf = dTreePdf = 0;
 		}

--- a/src/render/bsdf.h
+++ b/src/render/bsdf.h
@@ -17,27 +17,26 @@ public:
 	using TaggedPointer::TaggedPointer;
 
 	KRR_CALLABLE static BSDFSample sample(const SurfaceInteraction &intr, Vector3f wo, Sampler &sg,
-										  int bsdfIndex,
 										  TransportMode mode = TransportMode::Radiance) {
 		auto sample = [&](auto ptr)->BSDFSample {return ptr->sampleInternal(intr, wo, sg, mode); };
-		return dispatch(sample, bsdfIndex);
+		return dispatch(sample, static_cast<int>(intr.sd.bsdfType));
 	}
 
 	KRR_CALLABLE static Spectrum f(const SurfaceInteraction &intr, Vector3f wo, Vector3f wi,
-								int bsdfIndex, TransportMode mode = TransportMode::Radiance) {
+								TransportMode mode = TransportMode::Radiance) {
 		auto f = [&](auto ptr) -> Spectrum { return ptr->fInternal(intr, wo, wi, mode); };
-		return dispatch(f, bsdfIndex);
+		return dispatch(f, static_cast<int>(intr.sd.bsdfType));
 	}
 
-	KRR_CALLABLE static float pdf(const SurfaceInteraction &intr, Vector3f wo, Vector3f wi, int bsdfIndex,
+	KRR_CALLABLE static float pdf(const SurfaceInteraction &intr, Vector3f wo, Vector3f wi,
 								  TransportMode mode = TransportMode::Radiance) {
 		auto pdf = [&](auto ptr)->float {return ptr->pdfInternal(intr, wo, wi, mode); };
-		return dispatch(pdf, bsdfIndex);
+		return dispatch(pdf, static_cast<int>(intr.sd.bsdfType));
 	}
 
-	KRR_CALLABLE static BSDFType flags(const SurfaceInteraction& intr, int bsdfIndex) {
+	KRR_CALLABLE static BSDFType flags(const SurfaceInteraction& intr) {
 		auto flags = [&](auto ptr)->BSDFType {return ptr->flagsInternal(intr); };
-		return dispatch(flags, bsdfIndex);
+		return dispatch(flags, static_cast<int>(intr.sd.bsdfType));
 	}
 
 	KRR_CALLABLE void setup(const SurfaceInteraction &intr) {
@@ -68,6 +67,11 @@ public:
 		auto flags = [&](auto ptr) -> BSDFType { return ptr->flags(); };
 		return dispatch(flags);
 	}
+};
+
+class BSDF : public BxDF {
+public:
+	char data[MaximumSizeOfTypePack<Types>::value];
 };
 
 NAMESPACE_END(krr)

--- a/src/render/bsdf.h
+++ b/src/render/bsdf.h
@@ -69,9 +69,24 @@ public:
 	}
 };
 
+/* Another way to implement gpu polymorphism that is rather tricky, 
+*  avoiding initializing a BSDF multiple times within in a scope, 
+*  but needs a maximum size of the data array to be known at compile time.
+*/
 class BSDF : public BxDF {
 public:
-	char data[MaximumSizeOfTypePack<Types>::value];
+	using BxDF::BxDF;
+	KRR_CALLABLE BSDF(const SurfaceInteraction &intr) :
+		BxDF(data, 1 + static_cast<int>(intr.sd.bsdfType)) {
+		setup(intr);
+	}
+
+	BSDF(const BSDF &)			   = delete;
+	BSDF(const BSDF &&)			   = delete;
+	BSDF &operator=(const BSDF &)  = delete;
+	BSDF &operator=(const BSDF &&) = delete;
+
+	alignas(16) char data[MaximumSizeOfTypePack<Types>::value];
 };
 
 NAMESPACE_END(krr)

--- a/src/render/path/device.cu
+++ b/src/render/path/device.cu
@@ -97,10 +97,9 @@ KRR_DEVICE_FUNCTION void generateShadowRay(PathData& path) {
 	float lightPdf = sampledLight.pdf * ls.pdf;
 	if (lightPdf == 0)
 		return; // We have sampled on the primitive itself...
-	float bsdfPdf = light.isDeltaLight() ? 0 
-					: BxDF ::pdf(intr, woLocal, wiLocal, (int) intr.sd.bsdfType);
+	float bsdfPdf = light.isDeltaLight() ? 0 : BxDF ::pdf(intr, woLocal, wiLocal);
 	Spectrum bsdfVal =
-		BxDF::f(intr, woLocal, wiLocal, (int) intr.sd.bsdfType) * fabs(wiLocal[2]);
+		BxDF::f(intr, woLocal, wiLocal) * fabs(wiLocal[2]);
 	float misWeight = evalMIS(launchParams.lightSamples, lightPdf, 1, bsdfPdf);
 	if (isnan(misWeight) || isinf(misWeight) || !bsdfVal.any()) return;
 
@@ -121,7 +120,7 @@ KRR_DEVICE_FUNCTION void evalDirect(PathData& path) {
 KRR_DEVICE_FUNCTION bool generateScatterRay(PathData& path) {
 	const SurfaceInteraction &intr = path.intr;
 	Vector3f woLocal			   = intr.toLocal(intr.wo);
-	BSDFSample sample = BxDF::sample(intr, woLocal, path.sampler, (int) intr.sd.bsdfType);
+	BSDFSample sample = BxDF::sample(intr, woLocal, path.sampler);
 	if (sample.pdf == 0 || !any(sample.f)) return false;
 
 	Vector3f wiWorld = intr.toWorld(sample.wi);

--- a/src/render/path/device.cu
+++ b/src/render/path/device.cu
@@ -97,10 +97,10 @@ KRR_DEVICE_FUNCTION void generateShadowRay(PathData& path) {
 	float lightPdf = sampledLight.pdf * ls.pdf;
 	if (lightPdf == 0)
 		return; // We have sampled on the primitive itself...
-	float bsdfPdf = light.isDeltaLight() ? 0 : BxDF ::pdf(intr, woLocal, wiLocal);
-	Spectrum bsdfVal =
-		BxDF::f(intr, woLocal, wiLocal) * fabs(wiLocal[2]);
-	float misWeight = evalMIS(launchParams.lightSamples, lightPdf, 1, bsdfPdf);
+	BSDF bsdf(intr);
+	float bsdfPdf	 = light.isDeltaLight() ? 0 : bsdf.pdf(woLocal, wiLocal);
+	Spectrum bsdfVal = bsdf.f(woLocal, wiLocal) * fabs(wiLocal[2]);
+	float misWeight	 = evalMIS(launchParams.lightSamples, lightPdf, 1, bsdfPdf);
 	if (isnan(misWeight) || isinf(misWeight) || !bsdfVal.any()) return;
 
 	Ray shadowRay = intr.spawnRayTo(ls.intr);

--- a/src/render/wavefront/integrator.cpp
+++ b/src/render/wavefront/integrator.cpp
@@ -130,10 +130,8 @@ void WavefrontPathTracer::generateScatterRays(int depth) {
 				Vector3f wiLocal		  = intr.toLocal(wiWorld);
 
 				float lightPdf			= sampledLight.pdf * ls.pdf;
-				Spectrum bsdfVal = BxDF::f(intr, woLocal, wiLocal, (int) intr.sd.bsdfType);
-				float bsdfPdf			= light.isDeltaLight()
-											  ? 0
-											  : BxDF::pdf(intr, woLocal, wiLocal, (int) intr.sd.bsdfType);
+				Spectrum bsdfVal = BxDF::f(intr, woLocal, wiLocal);
+				float bsdfPdf			= light.isDeltaLight() ? 0 : BxDF::pdf(intr, woLocal, wiLocal);
 				if (lightPdf > 0 && bsdfVal.any()) {
 					ShadowRayWorkItem sw = {};
 					sw.ray				 = shadowRay;
@@ -147,7 +145,7 @@ void WavefrontPathTracer::generateScatterRays(int depth) {
 			}
 
 			/* sample BSDF */
-			BSDFSample sample = BxDF::sample(intr, woLocal, sampler, (int) intr.sd.bsdfType);
+			BSDFSample sample = BxDF::sample(intr, woLocal, sampler);
 			if (sample.pdf != 0 && sample.f.any()) {
 				Vector3f wiWorld = intr.toWorld(sample.wi);
 				RayWorkItem r	 = {};


### PR DESCRIPTION
(similar usage with TaggedPointer but wraps a std::variant)
now used in BSDF runtime dispatching, the performance seems to be similar as before though...